### PR TITLE
Potential fix for code scanning alert no. 3: CSRF protection not enabled

### DIFF
--- a/test/dummy/app/controllers/application_controller.rb
+++ b/test/dummy/app/controllers/application_controller.rb
@@ -1,2 +1,3 @@
 class ApplicationController < ActionController::Base
+  protect_from_forgery with: :exception
 end


### PR DESCRIPTION
Potential fix for [https://github.com/lcmen/testy_cookie/security/code-scanning/3](https://github.com/lcmen/testy_cookie/security/code-scanning/3)

To fix the problem, ensure that CSRF protection is explicitly enabled in the base controller by calling `protect_from_forgery` with a secure strategy, typically `with: :exception`. This enforces a CSRF token check on non-GET/HEAD/OPTIONS requests and raises an exception if the token is missing or invalid, preventing state-changing actions from being performed via forged requests.

The best way to do this without changing existing functionality is to add a single line inside `ApplicationController`:

```ruby
protect_from_forgery with: :exception
```

This should be added directly under the class declaration in `test/dummy/app/controllers/application_controller.rb`. No additional methods or imports are required because `protect_from_forgery` is provided by `ActionController::Base`. This change will apply to all controllers inheriting from `ApplicationController` and will not affect unrelated parts of the codebase.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
